### PR TITLE
headerdb: don't crash if a file doesn't exist

### DIFF
--- a/compdb/complementer/headerdb.py
+++ b/compdb/complementer/headerdb.py
@@ -67,6 +67,9 @@ def get_file_includes(path):
     Quote is one of double quote mark '\"' or opening angle bracket '<'.
     """
     includes = []
+    if not os.path.exists(path):
+        return includes
+
     with open(path, "rb") as istream:
         include_pattern = re.compile(
             br'\s*#\s*include\s+(?P<quote>["<])(?P<filename>.+?)[">]')


### PR DESCRIPTION
In some meson-ninja generated files I've references of not existing files.
Although this is an error, it shouldn't cause headerdb to crash.