### PR TITLE
headerdb: parse some special include search opts

### DIFF
--- a/compdb/complementer/headerdb.py
+++ b/compdb/complementer/headerdb.py
@@ -90,13 +90,18 @@ def extract_include_dirs(compile_command):
     i = 0
     arguments = sanitize_compile_options(compile_command)
     while i < len(arguments):
-        # -I <dir> and -I<dir>
-        if arguments[i].startswith("-I"):
-            if arguments[i] == "-I":
-                i += 1
-                header_search_path.append(arguments[i])
-            else:
-                header_search_path.append(arguments[i][2:])
+        # -I <dir> and -I<dir> and similar
+        for opt in ["-I", "-isystem", "-iquote", "-B"]:
+            if arguments[i].startswith(opt):
+                include_dir = None
+                if arguments[i] == opt:
+                    i += 1
+                    include_dir = arguments[i]
+                else:
+                    include_dir = arguments[i][len(opt):]
+                if opt == "-B":
+                    include_dir = os.path.join(include_dir, "include")
+                header_search_path.append(include_dir)
         i += 1
     return [
         os.path.join(compile_command.directory, p) for p in header_search_path

--- a/tests/unit/test_headerdb.py
+++ b/tests/unit/test_headerdb.py
@@ -78,21 +78,21 @@ class HeaderDB(unittest.TestCase):
         result = self.complement([
             CompileCommand(
                 directory=test_srcdir,
-                arguments=['clang++', '-Iinclude', '-DA=1'],
+                arguments=['clang++', '-iquote', 'include', '-DA=1'],
                 file='src/a.cpp'),
             CompileCommand(
                 directory=test_srcdir,
-                arguments=['clang++', '-Iinclude', '-DB=1'],
+                arguments=['clang++', '-iquoteinclude', '-DB=1'],
                 file='src/b.cpp'),
         ])
         self.assertEqual(2, len(result))
         self.assertEqual('include/a/a.hpp', result[0].file)
         self.assertEqual(
-            ['clang++', '-Iinclude', '-DA=1', '-c', 'include/a/a.hpp'],
+            ['clang++', '-iquote', 'include', '-DA=1', '-c', 'include/a/a.hpp'],
             result[0].arguments)
         self.assertEqual('include/b/b.hpp', result[1].file)
         self.assertEqual(
-            ['clang++', '-Iinclude', '-DB=1', '-c', 'include/b/b.hpp'],
+            ['clang++', '-iquoteinclude', '-DB=1', '-c', 'include/b/b.hpp'],
             result[1].arguments)
 
     def test_03(self):


### PR DESCRIPTION
Some projects use `-I` alternatives like `-isystem` to add directory into search path. Currently compdb skip this information and so miss some headers .
That options are almost identical to `-I` except some nuances not relevant to compdb. So i handle them just in parser.